### PR TITLE
Switch from -A to -M

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Please read the [standard Heroku docs](https://devcenter.heroku.com/articles/pre
 Create a `Procfile` in the root of your project to define which alias(es) will be used at startup
 
 ```
-web: clojure -A:my-alias-list
+web: clojure -M:my-alias-list
 ```
 
 ### Build Aliases [Optional]

--- a/bin/compile
+++ b/bin/compile
@@ -64,7 +64,7 @@ aliases_env=${BUILD_ALIASES}
 
 if [[ -n $aliases_env ]]
 then
-    aliases="-A$aliases_env"
+    aliases="-M$aliases_env"
     (cd $BUILD_DIR && clojure $aliases)
 fi
 
@@ -72,7 +72,7 @@ aliases_env=${TEST_ALIASES}
 
 if [[ -n $aliases_env ]]
 then
-    aliases="-A$aliases_env"
+    aliases="-M$aliases_env"
     (cd $BUILD_DIR && clojure $aliases)
 fi
 

--- a/bin/release
+++ b/bin/release
@@ -9,7 +9,7 @@ aliases=${ALIASES}
 
 if [[ -n $aliases ]]
 then
-    a_Opts="-A$aliases"
+    a_Opts="-M$aliases"
 fi
 
 # Java opts


### PR DESCRIPTION
Thanks for creating this @raymcdermott.

I get a warning while building:

```
WARNING: Use of :main-opts with -A is deprecated. Use -M instead.
```

(I'm building with figwheel-main). This isn't a critical issue right now, but may become one if/when `-A` stops allowing `:main-opts`?

I *think* that this can be fixed by simply moving from `-A` to `-M`, in which case see this pull request.